### PR TITLE
Bug fixes and feature enhancements

### DIFF
--- a/config/defaults.js
+++ b/config/defaults.js
@@ -37,6 +37,7 @@ define({
     "widgetTitleColor": "#008299",
     "toolsIconColor": "#008299",
     "toolOnByDefault": "none",
+     "visitStatusFilter": "All",
     "aboutFlag": false,
     "aboutText": "",
     "basemapFlag": true,

--- a/css/main.css
+++ b/css/main.css
@@ -304,6 +304,15 @@ body {
     max-height: 40vh;
     width: 100%;
 }
+.claro .dijitContentPane {
+    padding: 0px;
+}
+.esriViewPopup .header {
+    font-weight: normal;
+}
+.esriAttributeInspector .atiLayerName {
+display: none;
+}
 #dockContainer {
     margin-left: 0px;
     top: 39px;
@@ -422,19 +431,7 @@ body {
     border-top: 6px solid transparent;
     border-right: 6px solid #222;
 }
-.LayerSwipe .vertical {
-    background-color: azure;
-    width: 6px;
-    z-index: 1;
-}
-.LayerSwipe .horizontal {
-    background-color: azure;
-    height: 2px;
-}
-.LayerSwipe .vertical .handle{
-    background-color: #0080C0;
-    border: 0px solid transparent;
-}
+
 .claro .dijitDialog {
     background: #fff;
     border: 0 none;
@@ -736,7 +733,7 @@ body {
 .iconHeight {
     height: 15px;
 }
-#saveVisitBtn,#nextBtn,#addBookmark,#prevBtn,#submitAgolBtn,#exportBtn, #applyAOI, #resetAOI,#dropDownImageList,#dropDownImageListRight,#refreshImageSliderBtn,#refreshImageSliderBtnRight{
+#saveVisitBtn,#nextBtn,#prevBtn{
     text-align: center;
     background: #fff;
     /* border: 1px solid #ddd;*/
@@ -752,7 +749,7 @@ body {
     -webkit-font-smoothing: antialiased;
 }
 
-#saveVisitBtn:hover,#nextBtn:hover,#addBookmark:hover,#prevBtn:hover,#dropDownImageList:hover,#dropDownImageListRight:hover,#submitAgolBtn:hover,#exportBtn:hover, #refreshImageSliderBtn:hover,#refreshImageSliderBtnRight:hover{
+#saveVisitBtn:hover,#nextBtn:hover,#prevBtn:hover{
     background: #ddd;
 }
 .esriAttributeInspector .atiButton{
@@ -798,24 +795,6 @@ body {
     line-height: 40px;
 }
 
-#layerContainer {
-    display: block;
-    width: 30px;
-    height: 30px;
-    right: 20px;
-    top: 170px;
-    z-index: 10;
-    background: rgb(102,102,102);
-    cursor: pointer;
-    position: absolute;
-    border: 1px solid #999;
-}
-/*.basemapIcon:hover{
-    background-color: #008299;;
-}
-.basemapSelected{
-    background-color:#008299;
-}*/
 
 
 .closeContainerButton {
@@ -912,62 +891,7 @@ body {
     -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=65)";
     filter: alpha(opacity=65);
 }
-/*
-.BasemapToggle .toggleButton {
-    background: rgba(255,255,255,0.7);
-    -moz-user-select: -moz-none;
-    -ms-user-select: none;
-    -webkit-user-select: none;
-    user-select: none;
-    -moz-box-shadow: 0px 1px 1px rgba(0,0,0,0.5);
-    -webkit-box-shadow: 0px 1px 1px rgba(0,0,0,0.5);
-    box-shadow: 0px 1px 1px rgba(0,0,0,0.5);
-    cursor: pointer;
-    border:none;
-    border-radius:0 !important;
-    padding:0;
-}
-.BasemapToggle .basemapImageContainer {
-    position: relative;
-}
-.BasemapToggle .basemapImage {
-    width: 65px;
-    height: 65px;
-    overflow: hidden;
-}
-.BasemapToggle .basemapImage .basemapBG {
-    width: 100%;
-    height: 100%;
-    margin: 0;
-    padding: 0;
-    background-repeat: no-repeat;
-    background-position: center center;
-    border-radius: 0 !important;
-    padding:0;
-}
-.BasemapToggle .basemapTitle {
-    display: block;
-    width: 100%;
-    color: #4c4c4c;
-    margin: 0;
-    font-size: 10px;
-    line-height: 1.2;
-    padding: 4px;
-    background: #fff;
-    background: rgba(255,255,255,0.7);
-    text-align: center;
-    position: absolute;
-    bottom: 0;
-    z-index: 2;
-    -moz-box-sizing: border-box;
-    -webkit-box-sizing: border-box;
-    box-sizing: border-box;
-    border-radius: 0;
-}
 
-.BasemapToggle .basemapTitle {
-    font-family: "Times New Roman", Georgia, "Book Antiqua", serif;
-}*/
 .loading-indicator {
     /* Loading status */
     display: none;
@@ -1196,7 +1120,7 @@ body {
     font-size:0.8em;
     background: transparent;
     text-align: center;
-    width: 100%;
+    width: 110px;
     overflow: hidden;
     display: block;
 }

--- a/index.html
+++ b/index.html
@@ -33,14 +33,15 @@
         <div id="dockContainer" style='display: block;'><div id='widgetsContainer'>
                 <button role="button" aria-pressed="false" id='aboutContainer'  class="toolContainers"><img alt="" src='images/about.png' class='iconNode'/></button>
                 <button role="button" aria-pressed="false" id='visitContainer'  class="toolContainers"><span class="iconText"></span></button>
+                <!--<button role="button" aria-pressed="false" id='layerContainer'  class="toolContainers"><img alt="" src='images/operationalLayer.png' class='iconNode'/></button>-->
                 <button role="button" aria-pressed="false" id='measurementContainer'  class="toolContainers"><img alt="" src='images/measurement.png' class='iconNode'/></button>
                 <button role="button" aria-pressed="false" id='basemapContainer'  class="toolContainers"><img alt="" src='images/basemap.png' class='iconNode'/></button>
-        </div></div>
+            </div></div>
         <div class="mainContainer">
-        <div data-dojo-type="dijit/layout/ContentPane" data-dojo-props="resize: function(){}, focus: function(){}" id="toolsContentContainer" class="toolsContentContainer"></div>
-        <div id="mapDiv" dir="ltr"></div>
+            <div data-dojo-type="dijit/layout/ContentPane" data-dojo-props="resize: function(){}, focus: function(){}" id="toolsContentContainer" class="toolsContentContainer"></div>
+            <div id="mapDiv" dir="ltr"></div>
         </div>
-        <div role="button" tabindex="0" aria-label="Layer Toggle" id="layerContainer"><div id="layerIconNode" class="layerIcon"><img alt="" src='images/operationalLayer.png' height="20" width='20' style='margin: 5px;'/></div></div>
+        <!-- <div role="button" tabindex="0" aria-label="Layer Toggle" id="layerContainer"><div id="layerIconNode" class="layerIcon"><img alt="" src='images/operationalLayer.png' height="20" width='20' style='margin: 5px;'/></div></div>-->
         <script type="text/javascript">
             var package_path = window.location.pathname.substring(0, window.location.pathname.lastIndexOf('/'));
             var dojoConfig = {
@@ -58,9 +59,9 @@
                     }]
             };
             // Have to handle a locale parameter before dojo is loaded
-          if (location.search.match(/locale=([\w\-]+)/)) {
+            if (location.search.match(/locale=([\w\-]+)/)) {
                 dojoConfig.locale = RegExp.$1;
-          }
+            }
 
         </script>
         <script type="text/javascript" src="https://js.arcgis.com/3.24"></script>

--- a/js/nls/resources.js
+++ b/js/nls/resources.js
@@ -25,13 +25,6 @@ define({
         basemap: {
             title: "Basemap Gallery"
         },
-        layer: {
-            title: "Layer Toggle",
-            image: "Imagery",
-            visit: "Visit",
-            notes: "Notes",
-            error: "No layers present in the map."
-        },
         visit: {
             title: "Visit",
             visit: "Visit Attributes",
@@ -42,7 +35,19 @@ define({
             error: "Access denied. Layer cannot be edited.",
             edit: "Edit Notes",
             save: "Save",
-            filter: "Filter by visit status"
+            filter: "Filter by visit status",
+            all: "All",
+            record: "Record",
+            of: "of",
+            error1:"Please enter a valid numeric value.",
+            layer: "Layer Toggle",
+            imageLayer: "Imagery",
+            visitLayer: "Visit",
+            notesLayer: "Notes",
+            layerError: "No layers present in the map.",
+            follow: "Follow up",
+            okay: "Okay",
+            noStat: "No Status"
         },
         measurement: {
             title: "Image Measurement",

--- a/js/templates/Visit.html
+++ b/js/templates/Visit.html
@@ -1,17 +1,27 @@
 <div style="margin: 5px;overflow: hidden;">
+    <div id="layerContainer" style="display: none;">
+        <button id="layerAttributeBtn" class="titleHeader" role="button">
+            <span class="titleLabel">${config.i18n.visit.layer}</span>
+            <span class="launchpad-icon-arrow-right listExpandBtn"></span>
+        </button>
+        <div id="layerAttributesContent" style="display: none;padding: 0 0.8em"></div>
+    </div>
     <div id="filterVisitStatus" style="display: none;padding: 0.8em;">
-        <label for="selectFilter" class="titleLabel">${config.i18n.visit.filter}: </label>
+        <label for="selectFilter">${config.i18n.visit.filter}: </label>
         <select id="selectFilter" data-dojo-type="dijit/form/Select"></select>
+    </div>
+    <div id="recordDisplay" style="padding: 0.8em;display: none;">
+        <span>${config.i18n.visit.record}:</span><input id="recordIndex" data-dojo-type="dijit/form/NumberTextBox" style="width: 20%;" data-dojo-props="constraints:{place:0,min:1},invalidMessage:'${config.i18n.visit.error1}', rangeMessage: '${config.i18n.visit.error1}'"/>&nbsp;&nbsp;${config.i18n.visit.of}<span id="noOfRecords"></span>
     </div>
     <div id="visitAttributeContainer" style="display: none;">
         <button id="visitAttributeBtn" class="titleHeader" role="button">
             <span class="titleLabel">${config.i18n.visit.visit}</span>
             <span class="launchpad-icon-arrow-right listExpandBtn"></span>
         </button>
-        <div id="visitAttributesContent" style="display: none;">
+        <div id="visitAttributesContent" style="display: none;padding: 0 1.4em;">
             <div id="visitContentDiv" data-dojo-type="dijit/layout/ContentPane" 
                  data-dojo-props="region:'center'"></div>
-            <div id="setStatusField" style="display: none;padding: 0.8em;"><button data-dojo-type="dijit/form/Button" id="saveVisitBtn" style="margin-left:5px;">${config.i18n.visit.save}</button></div>
+            <div id="setStatusField" style="display: none;"><button data-dojo-type="dijit/form/Button" id="saveVisitBtn" style="margin-left:5px;">${config.i18n.visit.save}</button></div>
 
         </div>
     </div>
@@ -22,12 +32,12 @@
             <span class="launchpad-icon-arrow-right listExpandBtn"></span>
         </button>
         <div id="imageAttributesContent" data-dojo-type="dijit/layout/ContentPane" 
-             data-dojo-props="region:'center'" style="display: none;"></div>
+             data-dojo-props="region:'center'" style="display: none;padding: 0 1.4em;"></div>
     </div>
     <div id="editCheckbox" style="display: none;padding: 0.8em;"><input data-dojo-type="dijit/form/CheckBox" id="editToggle" /><label for="editToggle" class="titleLabel">${config.i18n.visit.edit}</label></div>
     <div id="errorEditor" style="color: #ee0000;"></div>
-    <div id="notesEditor" style="padding: 0.8em;display: none;">
-        <span id="textEditor" class="titleLabel">${config.i18n.visit.addText}</span>
+    <div id="notesEditor" style="padding: 0.8em 1.4em;display: none;">
+        <span id="textEditor">${config.i18n.visit.addText}</span>
         <div id="templateDiv" style="margin:5px;display: none;"></div>
         <div id="attributeInspectorDiv" data-dojo-type="dijit/layout/ContentPane" 
              data-dojo-props="region:'center'" style="display: block;"></div>

--- a/resources/configurationPanel.js
+++ b/resources/configurationPanel.js
@@ -1,456 +1,413 @@
 {
 "configurationSettings":[
-{
-"category":"General",
-        "fields":[
         {
-        "type":"webmap",
-                "conditions":["imagelayer"]
-        },
-        {
-        "placeHolder":"Enter the title",
-                "label":"Title:",
-                "fieldName":"title",
-                "type":"string",
-                "tooltip":"Provide App Name"
-        },
-        {
-        "placeHolder":"Description",
-                "label":"Description:",
-                "fieldName":"description",
-                "type":"string",
-                "tooltip":"Provide exciting info for the App title tooltip.",
-                "stringFieldOption":"textarea"
-        }
-        ]
-},
-{
-"category":"Theme",
-        "fields":[
-        {
-        "type":"paragraph",
-                "value":"<span style='text-align: justify;font-family: verdana;'>Define title header color for the app</span>"
-        },
-        {
-        "type":"color",
-                "fieldName":"background",
-                "tooltip":"Choose a title header color",
-                "label":"Title Header color"
-        },
-        {
-        "type":"color",
-                "fieldName":"color",
-                "tooltip":"Choose a text color for the app",
-                "label":"Text color"
-        },
-        {
-        "type":"color",
-                "fieldName":"widgetTitleColor",
-                "tooltip":"Choose a title header color",
-                "label":"Widget header color"
-        },
-        {
-        "type":"color",
-                "fieldName":"toolsIconColor",
-                "tooltip":"Choose an icon background color",
-                "label":"Icon background color"
-        },
-        {
-        "type":"paragraph",
-                "value":"<span style='text-align: justify;font-family: verdana;'>Use the Custom css option to paste css that overwrites rules in the app.</span>"
-        },
-        {
-        "type":"string",
-                "fieldName":"customstyle",
-                "tooltip":"Enter custom css",
-                "label":"Custom css"
-        }
-
-        ]
-},
-{
-"category": "Options",
-        "fields": [
-        {
-        "type":"options",
-                "fieldName":"toolOnByDefault",
-                "label":"Specify active tool at app startup",
-                "tooltip":"",
-                "options":[
-                {
-                "label":"None",
-                        "value":"none"
-                },
-                {
-                "label":"Visit",
-                        "value":"visit"
-                },
-                {
-                "label":"About",
-                        "value":"about"
-                }
-                ]
-        },
-        {
-        "type":"paragraph",
-                "value":"<span style='text-align: justify;font-family: verdana;'>Use the About tool to give your app context. Use this widget to explain to the user what the purpose of the app is and how to get started.</span>"
-        },
-        {
-        "type": "conditional",
-                "condition": false,
-                "fieldName": "aboutFlag",
-                "label": "Enable about tool",
-                "items": [
-                {
-                "type": "string",
-                        "fieldName": "aboutText",
-                        "label": "Text",
-                        "stringFieldOption": "richtext",
-                        "placeHolder": "Enter about text here."
-                }
-                ]
-        },
-        {
-        "type":"boolean",
-                "label":"Enable Basemap Gallery",
-                "fieldName":"basemapFlag",
-                "tooltip":"Basemap Selector"
-        },
-        {
-        "type":"conditional",
-                "condition":false,
-                "fieldName":"scalebarFlag",
-                "label":"Enable Scalebar",
-                "tooltip":"Display Scalebar",
-                "items":[
-                {
-                "type":"options",
-                        "fieldName":"scalebarPosition",
-                        "label":"Scalebar Position",
-                        "toolbar":"Select the Scalebar position on the map.",
-                        "options":[
-                        {
-                        "label":"Top Left",
-                                "value":"top-left"
-                        },
-                        {
-                        "label":"Top Right",
-                                "value":"top-right"
-                        },
-                        {
-                        "label":"Bottom Left",
-                                "value":"bottom-left"
-                        },
-                        {
-                        "label":"Bottom Right",
-                                "value":"bottom-right"
-                        },
-                        {
-                        "label":"Top Center",
-                                "value":"top-center"
-                        },
-                        {
-                        "label":"Bottom Center",
-                                "value":"bottom-center"
-                        }
-                        ]
-                },
-                {
-                "type":"options",
-                        "fieldName":"scalebarStyle",
-                        "label":"Scalebar Style",
-                        "toolbar":"Select the style for the scalebar.",
-                        "options":[
-                        {
-                        "label":"Ruler",
-                                "value":"ruler"
-                        },
-                        {
-                        "label":"Line",
-                                "value":"line"
-                        }
-                        ]
-                },
-                {
-                "type":"options",
-                        "fieldName":"scalebarUnit",
-                        "label":"Scalebar Unit",
-                        "toolbar":"Select the Scalebar units.",
-                        "options":[
-                        {
-                        "label":"English",
-                                "value":"english"
-                        },
-                        {
-                        "label":"Metric",
-                                "value":"metric"
-                        },
-                        {
-                        "label":"Both",
-                                "value":"dual"
-                        }
-                        ]
-                }
-                ]
-        },
-        {
-        "type":"boolean",
-                "label":"Enable Layer Toggle",
-                "fieldName":"layerFlag",
-                "tooltip":"Layer Toggle"
-        },
-        {
-        "type": "appproxies"
-        }
-        ]
-},
-{
-"category": "Imagery",
-        "fields": [
-        {
-        "type":"layerAndFieldSelector",
-                "fieldName":"imageLayer",
-                "label": "Imagery Layer",
-                "tooltip":"Select an image layer",
-                "layerOptions":{
-                "supportedTypes":[
-                        "ImageServiceLayer"
-                ]
-                },
-                "fields": [
-
-                ]
-        },
-        {
-        "type":"scaleList",
-                "fieldName":"zoomLevel",
-                "label":"Choose Zoom Level",
-                "tooltip":""
-        },
-        {
-        "type":"paragraph",
-                "value":"<p style='text-align:justify;font-family: verdana;'>The Image Measurement tool allows you to perform measurements on image services with mensuration capability. Mensuration applies geometric rules to find the height, area, or location of a feature.</p>"
-        },
-        {
-        "type":"conditional",
-                "condition":false,
-                "fieldName":"measurementFlag",
-                "label":"Image Measurement",
-                "tooltip": "Enable Image Measurement",
-                "items":[
-                {
-                "type":"paragraph",
-                        "value":"<p style='text-align:justify;font-family: verdana;margin-bottom:0px;'>Select the units that will be displayed in-app using the dropdown menus.</p>"
-                },
-                {
-                "type":"options",
-                        "fieldName":"angularUnit",
-                        "label":"Default Angular Unit",
-                        "tooltip":"Unit of measure for angular measurement.",
-                        "options":[
-                        {
-                        "label":"Radians",
-                                "value":"esriDURadians"
-                        },
-                        {
-                        "label":"Degrees",
-                                "value":"esriDUDecimalDegrees"
-                        }
-                        ]
-                },
-                {
-                "type":"options",
-                        "fieldName":"linearUnit",
-                        "label":"Default Linear Unit",
-                        "tooltip":"Unit of measure for linear measurement.",
-                        "options":[
-                        {
-                        "label":"Inches",
-                                "value":"esriInches"
-                        },
-                        {
-                        "label":"Feet",
-                                "value":"esriFeet"
-                        },
-                        {
-                        "label":"Yards",
-                                "value":"esriYards"
-                        },
-                        {
-                        "label":"Miles",
-                                "value":"esriMiles"
-                        },
-                        {
-                        "label":"Nautical Miles",
-                                "value":"esriNauticalMiles"
-                        },
-                        {
-                        "label":"Millimeters",
-                                "value":"esriMillimeters"
-                        },
-                        {
-                        "label":"Centimeters",
-                                "value":"esriCentimeters"
-                        },
-                        {
-                        "label":"Decimeters",
-                                "value":"esriDecimeters"
-                        },
-                        {
-                        "label":"Meters",
-                                "value":"esriMeters"
-                        },
-                        {
-                        "label":"Kilometers",
-                                "value":"esriKilometers"
-                        }
-                        ]
-                },
-                {
-                "type":"options",
-                        "fieldName":"areaUnit",
-                        "label":"Default Area Unit",
-                        "tooltip":"Unit of measure for area measurement.",
-                        "options":[
-                        {
-                        "label":"Sq Inches",
-                                "value":"esriSquareInches"
-                        },
-                        {
-                        "label":"Sq Feet",
-                                "value":"esriSquareFeet"
-                        },
-                        {
-                        "label":"Sq Yards",
-                                "value":"esriSquareYards"
-                        },
-                        {
-                        "label":"Acres",
-                                "value":"esriAcres"
-                        },
-                        {
-                        "label":"Sq Miles",
-                                "value":"esriSquareMiles"
-                        },
-                        {
-                        "label":"Sq Millimeters",
-                                "value":"esriSquareMillimeters"
-                        },
-                        {
-                        "label":"Sq Centimeters",
-                                "value":"esriSquareCentimeters"
-                        },
-                        {
-                        "label":"Sq Decimeters",
-                                "value":"esriSquareDecimeters"
-                        },
-                        {
-                        "label":"Sq Meters",
-                                "value":"esriSquareMeters"
-                        },
-                        {
-                        "label":"Ares",
-                                "value":"esriAres"
-                        },
-                        {
-                        "label":"Hectares",
-                                "value":"esriHectares"
-                        },
-                        {
-                        "label":"Sq Kilometers",
-                                "value":"esriSquareKilometers"
-                        }
-                        ]
-                }
-                ]
-        },
-        {
-        "type": "paragraph",
-                "value": "<span style='font-weight: bold; font-size: 14px;'>Image Visit</span>"
-        },
-        {
-        "type":"layerAndFieldSelector",
-                "fieldName":"visitLayer",
-                "label":"Visit Layer",
-                "tooltip":"Select Visit Layer",
+        "category":"General",
                 "fields":[
                 {
-                "multipleSelection":false,
-                        "fieldName":"visitOrderField",
-                        "label":"Visit Order (Optional)",
-                        "tooltip":"Select a visit order field",
-                        "supportedTypes":[
-                                "esriFieldTypeSmallInteger",
-                                "esriFieldTypeInteger",
-                                "esriFieldTypeSingle",
-                                "esriFieldTypeDouble",
-                                "esriFieldTypeOID"
-                        ]
+                "type":"webmap",
+                        "conditions":["imagelayer"]
                 },
                 {
-                "multipleSelection":false,
-                        "fieldName":"statusField",
-                        "label":"Status (Optional)",
-                        "tooltip":"Select a status field",
-                        "supportedTypes":[
-                                "esriFieldTypeSmallInteger",
-                                "esriFieldTypeInteger",
-                                "esriFieldTypeSingle",
-                                "esriFieldTypeDouble",
-                                "esriFieldTypeString",
-                                "esriFieldTypeDate",
-                                "esriFieldTypeOID",
-                                "esriFieldTypeGeometry",
-                                "esriFieldTypeBlob",
-                                "esriFieldTypeRaster",
-                                "esriFieldTypeGUID",
-                                "esriFieldTypeGlobalID",
-                                "esriFieldTypeXML"
-                        ]
+                "placeHolder":"Enter the title",
+                        "label":"Title:",
+                        "fieldName":"title",
+                        "type":"string",
+                        "tooltip":"Provide App Name"
+                },
+                {
+                "placeHolder":"Description",
+                        "label":"Description:",
+                        "fieldName":"description",
+                        "type":"string",
+                        "tooltip":"Provide exciting info for the App title tooltip.",
+                        "stringFieldOption":"textarea"
                 }
-                ],
-                "layerOptions":{
-                "supportedTypes":[
-                        "FeatureLayer"
                 ]
-                }
-        },
+                },
         {
-        "type":"conditional",
-                "condition": false,
-                "fieldName":"imageFilterFlag",
-                "label":"Image Filter",
-                "tooltip": "Enable Image Filter",
-                "items":[
+        "category":"Theme",
+                "fields":[
+                {
+                "type":"paragraph",
+                        "value":"<span style='text-align: justify;font-family: verdana;'>Define title header color for the app</span>"
+                },
+                {
+                "type":"color",
+                        "fieldName":"background",
+                        "tooltip":"Choose a title header color",
+                        "label":"Title Header color"
+                },
+                {
+                "type":"color",
+                        "fieldName":"color",
+                        "tooltip":"Choose a text color for the app",
+                        "label":"Text color"
+                },
+                {
+                "type":"color",
+                        "fieldName":"widgetTitleColor",
+                        "tooltip":"Choose a title header color",
+                        "label":"Widget header color"
+                },
+                {
+                "type":"color",
+                        "fieldName":"toolsIconColor",
+                        "tooltip":"Choose an icon background color",
+                        "label":"Icon background color"
+                },
+                {
+                "type":"paragraph",
+                        "value":"<span style='text-align: justify;font-family: verdana;'>Use the Custom css option to paste css that overwrites rules in the app.</span>"
+                },
                 {
                 "type":"string",
-                        "fieldName": "visitFilterField",
-                        "label":"Display imagery only if",
-                        "tooltip": "",
-                        "stringFieldOption": "textbox",
-                        "placeHolder": "Enter visit layer field"
+                        "fieldName":"customstyle",
+                        "tooltip":"Enter custom css",
+                        "label":"Custom css"
+                }
+
+                ]
+                },
+        {
+        "category": "Options",
+                "fields": [
+                {
+                "type":"options",
+                        "fieldName":"toolOnByDefault",
+                        "label":"Specify active tool at app startup",
+                        "tooltip":"",
+                        "options":[
+                        {
+                        "label":"None",
+                                "value":"none"
+                        },
+                        {
+                        "label":"Visit",
+                                "value":"visit"
+                        },
+                        {
+                        "label":"About",
+                                "value":"about"
+                        }
+                        ]
                 },
                 {
-                "type": "string",
-                        "fieldName":"imageFilterField",
-                        "label":"matches",
-                        "stringFieldOption": "textbox",
-                        "placeHolder": "Enter imagery layer field"
+                "type":"paragraph",
+                        "value":"<span style='text-align: justify;font-family: verdana;'>Use the About tool to give your app context. Use this widget to explain to the user what the purpose of the app is and how to get started.</span>"
+                },
+                {
+                "type": "conditional",
+                        "condition": false,
+                        "fieldName": "aboutFlag",
+                        "label": "Enable about tool",
+                        "items": [
+                        {
+                        "type": "string",
+                                "fieldName": "aboutText",
+                                "label": "Text",
+                                "stringFieldOption": "richtext",
+                                "placeHolder": "Enter about text here."
+                        }
+                        ]
+                },
+                {
+                "type":"boolean",
+                        "label":"Enable Basemap Gallery",
+                        "fieldName":"basemapFlag",
+                        "tooltip":"Basemap Selector"
+                },
+                {
+                "type":"conditional",
+                        "condition":false,
+                        "fieldName":"scalebarFlag",
+                        "label":"Enable Scalebar",
+                        "tooltip":"Display Scalebar",
+                        "items":[
+                        {
+                        "type":"options",
+                                "fieldName":"scalebarPosition",
+                                "label":"Scalebar Position",
+                                "toolbar":"Select the Scalebar position on the map.",
+                                "options":[
+                                {
+                                "label":"Top Left",
+                                        "value":"top-left"
+                                },
+                                {
+                                "label":"Top Right",
+                                        "value":"top-right"
+                                },
+                                {
+                                "label":"Bottom Left",
+                                        "value":"bottom-left"
+                                },
+                                {
+                                "label":"Bottom Right",
+                                        "value":"bottom-right"
+                                },
+                                {
+                                "label":"Top Center",
+                                        "value":"top-center"
+                                },
+                                {
+                                "label":"Bottom Center",
+                                        "value":"bottom-center"
+                                }
+                                ]
+                        },
+                        {
+                        "type":"options",
+                                "fieldName":"scalebarStyle",
+                                "label":"Scalebar Style",
+                                "toolbar":"Select the style for the scalebar.",
+                                "options":[
+                                {
+                                "label":"Ruler",
+                                        "value":"ruler"
+                                },
+                                {
+                                "label":"Line",
+                                        "value":"line"
+                                }
+                                ]
+                        },
+                        {
+                        "type":"options",
+                                "fieldName":"scalebarUnit",
+                                "label":"Scalebar Unit",
+                                "toolbar":"Select the Scalebar units.",
+                                "options":[
+                                {
+                                "label":"English",
+                                        "value":"english"
+                                },
+                                {
+                                "label":"Metric",
+                                        "value":"metric"
+                                },
+                                {
+                                "label":"Both",
+                                        "value":"dual"
+                                }
+                                ]
+                        }
+                        ]
+                },
+                {
+                "type":"boolean",
+                        "label":"Enable Layer Toggle",
+                        "fieldName":"layerFlag",
+                        "tooltip":"Layer Toggle"
+                },
+                {
+                "type": "appproxies"
                 }
                 ]
-        },
+                },
         {
-        "type":"conditional",
-                "condition": false,
-                "fieldName":"userNotesFlag",
-                "label":"User Notes",
-                "items":[
+        "category": "Imagery",
+                "fields": [
                 {
                 "type":"layerAndFieldSelector",
-                        "fieldName":"notesLayer",
-                        "label":"Notes Layer",
-                        "tooltip":"Select editable Notes Layer",
+                        "fieldName":"imageLayer",
+                        "label": "Imagery Layer",
+                        "tooltip":"Select an image layer",
+                        "layerOptions":{
+                        "supportedTypes":[
+                                "ImageServiceLayer"
+                        ]
+                        },
+                        "fields": [
+
+                        ]
+                },
+                {
+                "type":"scaleList",
+                        "fieldName":"zoomLevel",
+                        "label":"Choose Zoom Level",
+                        "tooltip":""
+                },
+                {
+                "type":"paragraph",
+                        "value":"<p style='text-align:justify;font-family: verdana;'>The Image Measurement tool allows you to perform measurements on image services with mensuration capability. Mensuration applies geometric rules to find the height, area, or location of a feature.</p>"
+                },
+                {
+                "type":"conditional",
+                        "condition":false,
+                        "fieldName":"measurementFlag",
+                        "label":"Image Measurement",
+                        "tooltip": "Enable Image Measurement",
+                        "items":[
+                        {
+                        "type":"paragraph",
+                                "value":"<p style='text-align:justify;font-family: verdana;margin-bottom:0px;'>Select the units that will be displayed in-app using the dropdown menus.</p>"
+                        },
+                        {
+                        "type":"options",
+                                "fieldName":"angularUnit",
+                                "label":"Default Angular Unit",
+                                "tooltip":"Unit of measure for angular measurement.",
+                                "options":[
+                                {
+                                "label":"Radians",
+                                        "value":"esriDURadians"
+                                },
+                                {
+                                "label":"Degrees",
+                                        "value":"esriDUDecimalDegrees"
+                                }
+                                ]
+                        },
+                        {
+                        "type":"options",
+                                "fieldName":"linearUnit",
+                                "label":"Default Linear Unit",
+                                "tooltip":"Unit of measure for linear measurement.",
+                                "options":[
+                                {
+                                "label":"Inches",
+                                        "value":"esriInches"
+                                },
+                                {
+                                "label":"Feet",
+                                        "value":"esriFeet"
+                                },
+                                {
+                                "label":"Yards",
+                                        "value":"esriYards"
+                                },
+                                {
+                                "label":"Miles",
+                                        "value":"esriMiles"
+                                },
+                                {
+                                "label":"Nautical Miles",
+                                        "value":"esriNauticalMiles"
+                                },
+                                {
+                                "label":"Millimeters",
+                                        "value":"esriMillimeters"
+                                },
+                                {
+                                "label":"Centimeters",
+                                        "value":"esriCentimeters"
+                                },
+                                {
+                                "label":"Decimeters",
+                                        "value":"esriDecimeters"
+                                },
+                                {
+                                "label":"Meters",
+                                        "value":"esriMeters"
+                                },
+                                {
+                                "label":"Kilometers",
+                                        "value":"esriKilometers"
+                                }
+                                ]
+                        },
+                        {
+                        "type":"options",
+                                "fieldName":"areaUnit",
+                                "label":"Default Area Unit",
+                                "tooltip":"Unit of measure for area measurement.",
+                                "options":[
+                                {
+                                "label":"Sq Inches",
+                                        "value":"esriSquareInches"
+                                },
+                                {
+                                "label":"Sq Feet",
+                                        "value":"esriSquareFeet"
+                                },
+                                {
+                                "label":"Sq Yards",
+                                        "value":"esriSquareYards"
+                                },
+                                {
+                                "label":"Acres",
+                                        "value":"esriAcres"
+                                },
+                                {
+                                "label":"Sq Miles",
+                                        "value":"esriSquareMiles"
+                                },
+                                {
+                                "label":"Sq Millimeters",
+                                        "value":"esriSquareMillimeters"
+                                },
+                                {
+                                "label":"Sq Centimeters",
+                                        "value":"esriSquareCentimeters"
+                                },
+                                {
+                                "label":"Sq Decimeters",
+                                        "value":"esriSquareDecimeters"
+                                },
+                                {
+                                "label":"Sq Meters",
+                                        "value":"esriSquareMeters"
+                                },
+                                {
+                                "label":"Ares",
+                                        "value":"esriAres"
+                                },
+                                {
+                                "label":"Hectares",
+                                        "value":"esriHectares"
+                                },
+                                {
+                                "label":"Sq Kilometers",
+                                        "value":"esriSquareKilometers"
+                                }
+                                ]
+                        }
+                        ]
+                },
+                {
+                "type": "paragraph",
+                        "value": "<span style='font-weight: bold; font-size: 14px;'>Image Visit</span>"
+                },
+                {
+                "type":"layerAndFieldSelector",
+                        "fieldName":"visitLayer",
+                        "label":"Visit Layer",
+                        "tooltip":"Select Visit Layer",
                         "fields":[
+                        {
+                        "multipleSelection":false,
+                                "fieldName":"visitOrderField",
+                                "label":"Visit Order (Optional)",
+                                "tooltip":"Select a visit order field",
+                                "supportedTypes":[
+                                        "esriFieldTypeSmallInteger",
+                                        "esriFieldTypeInteger",
+                                        "esriFieldTypeSingle",
+                                        "esriFieldTypeDouble",
+                                        "esriFieldTypeOID"
+                                ]
+                        },
+                        {
+                        "multipleSelection":false,
+                                "fieldName":"statusField",
+                                "label":"Status (Optional)",
+                                "tooltip":"Select a status field",
+                                "supportedTypes":[
+                                        "esriFieldTypeSmallInteger",
+                                        "esriFieldTypeInteger",
+                                        "esriFieldTypeSingle",
+                                        "esriFieldTypeDouble",
+                                        "esriFieldTypeString",
+                                        "esriFieldTypeDate",
+                                        "esriFieldTypeOID",
+                                        "esriFieldTypeGeometry",
+                                        "esriFieldTypeBlob",
+                                        "esriFieldTypeRaster",
+                                        "esriFieldTypeGUID",
+                                        "esriFieldTypeGlobalID",
+                                        "esriFieldTypeXML"
+                                ]
+                        }
                         ],
                         "layerOptions":{
                         "supportedTypes":[
@@ -459,51 +416,101 @@
                         }
                 },
                 {
-                "type": "options",
-                        "fieldName": "notesMode",
-                        "tooltip": "Select Notes Mode",
-                        "label": "Notes Mode:",
-                        "options": [{
-                        "label": "Copy visit feature",
-                                "value": "copy"
-                        }, {
-                        "label": "User adds one feature",
-                                "value": "one"
-                        }, {
-                        "label": "User adds many features",
-                                "value": "many"
-                        }]
-                }
-
-                ]
-        }
-
-        ]
-},
-{
-"category": "Search",
-        "fields": [
-        {
-        "type":"paragraph",
-                "value":"<span style='text-align: justify;font-family: verdana;'>Enable search to allow users to find a location or data in the map. Configure the search settings to refine the experience in your app by setting the default search resource, placeholder text, etc.</span>"
-        },
-        {
-        "type":"conditional",
-                "condition":false,
-                "fieldName":"search",
-                "label":"Enable search tool",
-                "items":[
+                "type": "string",
+                        "fieldName":"visitStatusFilter",
+                        "label":"Status Filter Value:",
+                        "stringFieldOption": "textbox",
+                        "placeHolder": "Enter filter value for above selected Status field"
+                },
                 {
-                "type":"search",
-                        "fieldName":"searchConfig",
-                        "label":"Configure search tool"
+                "type":"conditional",
+                        "condition": false,
+                        "fieldName":"imageFilterFlag",
+                        "label":"Image Filter",
+                        "tooltip": "Enable Image Filter",
+                        "items":[
+                        {
+                        "type":"string",
+                                "fieldName": "visitFilterField",
+                                "label":"Display imagery only if",
+                                "tooltip": "",
+                                "stringFieldOption": "textbox",
+                                "placeHolder": "Enter visit layer field"
+                        },
+                        {
+                        "type": "string",
+                                "fieldName":"imageFilterField",
+                                "label":"matches",
+                                "stringFieldOption": "textbox",
+                                "placeHolder": "Enter imagery layer field"
+                        }
+                        ]
+                },
+                {
+                "type":"conditional",
+                        "condition": false,
+                        "fieldName":"userNotesFlag",
+                        "label":"User Notes",
+                        "items":[
+                        {
+                        "type":"layerAndFieldSelector",
+                                "fieldName":"notesLayer",
+                                "label":"Notes Layer",
+                                "tooltip":"Select editable Notes Layer",
+                                "fields":[
+                                ],
+                                "layerOptions":{
+                                "supportedTypes":[
+                                        "FeatureLayer"
+                                ]
+                                }
+                        },
+                        {
+                        "type": "options",
+                                "fieldName": "notesMode",
+                                "tooltip": "Select Notes Mode",
+                                "label": "Notes Mode:",
+                                "options": [{
+                                "label": "Copy visit feature",
+                                        "value": "copy"
+                                }, {
+                                "label": "User adds one feature",
+                                        "value": "one"
+                                }, {
+                                "label": "User adds many features",
+                                        "value": "many"
+                                }]
+                        }
+
+                        ]
+                }
+
+                ]
+                },
+        {
+        "category": "Search",
+                "fields": [
+                {
+                "type":"paragraph",
+                        "value":"<span style='text-align: justify;font-family: verdana;'>Enable search to allow users to find a location or data in the map. Configure the search settings to refine the experience in your app by setting the default search resource, placeholder text, etc.</span>"
+                },
+                {
+                "type":"conditional",
+                        "condition":false,
+                        "fieldName":"search",
+                        "label":"Enable search tool",
+                        "items":[
+                        {
+                        "type":"search",
+                                "fieldName":"searchConfig",
+                                "label":"Configure search tool"
+                        }
+                        ]
                 }
                 ]
-        }
-        ]
 
 
-}
+                }
 ],
         "values":{
         "title": "Image Visit",
@@ -524,6 +531,7 @@
                 "imageLayer": {"id": null},
                 "zoomLevel": "",
                 "visitLayer": {"id": null, "fields":[]},
+                "visitStatusFilter": "All",
                 "imageFilterFlag": false,
                 "visitFilterField":"",
                 "imageFilterField":"",


### PR DESCRIPTION
bug fixes and feature enhancements:
•	Need to know how many records are being returned, and which number you're on ("3 of 30," for example) - done

•	Need a warning when you reach the end, before Next returns you to the first record - no need next button is disabled as you reach the end. Previous becomes disabled when you reach the first record.

•	Add the option to jump to a feature number (useful when reviewing large datasets) -done

•	 We need a way for users to toggle the imagery layer on/off without leaving the Visit tool. Move check boxes for toggling layers into the Visit tool dialog somewhere--could be incorporated at the top, maybe?  - done

•	For all three datasets, can we use the name of the layer in the web map, rather than the name of the service? (e.g. Vexel Imagery - Santa Rosa, CA fire VS. VexcelDRP/VexcelDRP_Multispectral:Tubbs_00408-Col) - this has to be done by the author of the webmap. He/she can configure the popup content in the webmap. I just display the contents of popup in the dialog. Popup title can be changed in the webmap while configuring the popup.

•	How much control do you have over the formatting in the dialog? Can we un-bold everything except the three section headings (Visit Attributes, Image Attributes, Edit Notes)? Or make these three headings slightly bigger? We need more contrast to make it easier to scan for the three sections in the Visit dialog. - done

•	In "User adds one feature" mode, if the user adds a feature, then deletes another feature (e.g. a feature created by another user), they are given the option to add a second feature. Is there a way to have the app remember WHICH feature the user created (and should delete before getting the option to add another feature)? - done

•	Set the default status, if no schema, to "No Status" instead of "Follow Up" - done

•	If there's no Notes layer, clicking the "Save" button after editing the status should go to the next Visit location automatically - done

•	As for bugs, please try to address the issues that you can identify (e.g. "When using the default status (okay/follow up/no status), the Status in the visit layer attributes lists the value (1/0/-1), not the alias"). - if no status schema is defined then I populate the status dropdown with (okay/follow up/no status) but the actual values entered into the database is (1/0/-1). Popup will only show the actual values. If you don't want these values to appear, then I will enter (okay/follow up/no status) into the database instead of (1/0/-1)

•	Could the Previous and Next be associated with short cuts (e.g. N and P)?  - There are lot of cases where this implementation will cause an issue.
•	On loading the next image, the query for the data of the current image attributes appears to be done then vs in advance. Also the query appears to be returning a lot of geometry. Is this the efficient way to get the image date, etc.?- done. Currently I don’t have any other way to get the image attributes. I make an identify request by clicking on the map (programmatically) It is similar to how you do identify in webmap.